### PR TITLE
Add dark mode theme toggle for contest landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,9 +9,13 @@
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;500;700&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="styles.css" />
 </head>
-<body id="top">
+<body id="top" data-theme="light">
   <header class="hero">
     <div class="hero__overlay" aria-hidden="true"></div>
+    <button class="theme-toggle" type="button" aria-label="Toggle dark mode">
+      <span class="theme-toggle__icon" aria-hidden="true"></span>
+      <span class="theme-toggle__label">Dark mode</span>
+    </button>
     <div class="container hero__content">
       <p class="eyebrow">Ieeja Cultural Collective Presents</p>
       <h1>Ieeja Voices Singing Contest</h1>
@@ -130,5 +134,43 @@
       <a href="#top" class="footer__top">Back to top</a>
     </div>
   </footer>
+  <script>
+    (function () {
+      const storageKey = 'ieeja-theme';
+      const classNameDark = 'dark';
+      const themeToggle = document.querySelector('.theme-toggle');
+      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
+
+      const getStoredTheme = () => localStorage.getItem(storageKey);
+      const setTheme = (theme) => {
+        document.body.setAttribute('data-theme', theme);
+        localStorage.setItem(storageKey, theme);
+        themeToggle?.setAttribute('aria-pressed', theme === classNameDark ? 'true' : 'false');
+      };
+
+      const initTheme = () => {
+        const storedTheme = getStoredTheme();
+        if (storedTheme === classNameDark || storedTheme === 'light') {
+          setTheme(storedTheme);
+        } else {
+          setTheme(prefersDark.matches ? classNameDark : 'light');
+        }
+      };
+
+      themeToggle?.addEventListener('click', () => {
+        const current = document.body.getAttribute('data-theme');
+        setTheme(current === classNameDark ? 'light' : classNameDark);
+      });
+
+      prefersDark.addEventListener('change', (event) => {
+        const storedTheme = getStoredTheme();
+        if (!storedTheme) {
+          setTheme(event.matches ? classNameDark : 'light');
+        }
+      });
+
+      initTheme();
+    })();
+  </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
 <body id="top" data-theme="light">
   <header class="hero">
     <div class="hero__overlay" aria-hidden="true"></div>
-    <button class="theme-toggle" type="button" aria-label="Toggle dark mode">
+    <button class="theme-toggle" type="button" aria-label="Toggle dark mode" aria-pressed="false">
       <span class="theme-toggle__icon" aria-hidden="true"></span>
       <span class="theme-toggle__label">Dark mode</span>
     </button>
@@ -140,12 +140,20 @@
       const classNameDark = 'dark';
       const themeToggle = document.querySelector('.theme-toggle');
       const prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
+      const toggleLabel = themeToggle?.querySelector('.theme-toggle__label');
 
       const getStoredTheme = () => localStorage.getItem(storageKey);
       const setTheme = (theme) => {
         document.body.setAttribute('data-theme', theme);
         localStorage.setItem(storageKey, theme);
-        themeToggle?.setAttribute('aria-pressed', theme === classNameDark ? 'true' : 'false');
+        const isDark = theme === classNameDark;
+        themeToggle?.setAttribute('aria-pressed', isDark ? 'true' : 'false');
+        if (themeToggle) {
+          themeToggle.setAttribute('aria-label', isDark ? 'Toggle light mode' : 'Toggle dark mode');
+        }
+        if (toggleLabel) {
+          toggleLabel.textContent = isDark ? 'Light mode' : 'Dark mode';
+        }
       };
 
       const initTheme = () => {

--- a/styles.css
+++ b/styles.css
@@ -1,12 +1,28 @@
 :root {
+  color-scheme: light;
   --color-primary: #ff5a5f;
   --color-primary-dark: #d83c59;
   --color-surface: #ffffff;
   --color-background: #fdfcff;
   --color-muted: #f2f1ff;
+  --color-accent-bg: rgba(255, 90, 95, 0.08);
+  --color-timeline-ring: rgba(117, 98, 255, 0.1);
   --color-text: #201836;
   --color-text-soft: #6c6783;
   --font-base: 'Poppins', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+[data-theme='dark'] {
+  color-scheme: dark;
+  --color-primary: #ff7d8f;
+  --color-primary-dark: #ff8bba;
+  --color-surface: #211832;
+  --color-background: #0f0b1d;
+  --color-muted: #181129;
+  --color-accent-bg: rgba(255, 118, 138, 0.12);
+  --color-timeline-ring: rgba(255, 139, 186, 0.22);
+  --color-text: #f5f2ff;
+  --color-text-soft: #c5c0de;
 }
 
 * {
@@ -20,6 +36,60 @@ body {
   color: var(--color-text);
   line-height: 1.6;
   scroll-behavior: smooth;
+}
+
+.theme-toggle {
+  position: absolute;
+  top: clamp(1rem, 4vw, 2rem);
+  right: clamp(1rem, 4vw, 2rem);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.65rem;
+  border: none;
+  background: rgba(255, 255, 255, 0.18);
+  color: white;
+  padding: 0.55rem 0.95rem;
+  border-radius: 999px;
+  font-weight: 600;
+  cursor: pointer;
+  backdrop-filter: blur(12px);
+  transition: transform 0.25s ease, background 0.25s ease;
+}
+
+.theme-toggle:hover,
+.theme-toggle:focus-visible {
+  transform: translateY(-2px);
+  background: rgba(255, 255, 255, 0.28);
+}
+
+.theme-toggle__icon {
+  width: 1.4rem;
+  height: 1.4rem;
+  border-radius: 50%;
+  background: radial-gradient(circle at 30% 30%, #fff 45%, rgba(255, 255, 255, 0.4) 60%);
+  position: relative;
+  transition: transform 0.4s ease, background 0.4s ease;
+}
+
+.theme-toggle[aria-pressed='true'] .theme-toggle__icon {
+  transform: rotate(-25deg);
+  background:
+    radial-gradient(circle at 30% 30%, #ffd27d 45%, rgba(255, 210, 125, 0.45) 60%),
+    radial-gradient(circle at 70% 70%, rgba(17, 12, 31, 0.65) 10%, transparent 60%);
+}
+
+.theme-toggle__label {
+  font-size: 0.9rem;
+}
+
+[data-theme='dark'] .theme-toggle {
+  background: rgba(33, 24, 50, 0.7);
+  color: var(--color-text);
+}
+
+[data-theme='dark'] .theme-toggle:hover,
+[data-theme='dark'] .theme-toggle:focus-visible {
+  background: rgba(49, 36, 73, 0.85);
 }
 
 a {
@@ -261,7 +331,7 @@ main {
 }
 
 .section--accent {
-  background: rgba(255, 90, 95, 0.08);
+  background: var(--color-accent-bg);
   padding-block: clamp(3.5rem, 7vw, 5rem);
 }
 
@@ -299,7 +369,7 @@ main {
   padding: 1rem 1.2rem;
   border-radius: 18px;
   background: var(--color-muted);
-  box-shadow: inset 0 0 0 1px rgba(117, 98, 255, 0.1);
+  box-shadow: inset 0 0 0 1px var(--color-timeline-ring);
   animation: fadeUp 0.7s ease both;
 }
 


### PR DESCRIPTION
## Summary
- add a hero-mounted toggle that switches between light and dark themes with stored preferences
- extend the design token palette and component styles to support the new dark appearance

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68db7ab4bc08832ebb2f091d5aef66de